### PR TITLE
Upgrade to Neo4j 2.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN wget -O - http://debian.neo4j.org/neotechnology.gpg.key | apt-key add - && \
     echo 'deb http://debian.neo4j.org/repo stable/' > /etc/apt/sources.list.d/neo4j.list && \
     apt-get update ; apt-get install neo4j -y
 
-WORKDIR /etc/neo4j
+WORKDIR /var/lib/neo4j
 
 # Copy graph analytics plugin
 COPY plugins /var/lib/neo4j/plugins
@@ -27,6 +27,7 @@ RUN chown root:root /etc/bootstrap.sh && \
 # Customize configurations
 RUN apt-get clean && \
     sed -i "s|data/graph.db|/opt/data/graph.db|g" /var/lib/neo4j/conf/neo4j-server.properties && \
+    sed -i "s|dbms.security.auth_enabled=true|dbms.security.auth_enabled=false|g" /var/lib/neo4j/conf/neo4j-server.properties && \
     sed -i "s|#org.neo4j.server.webserver.address|org.neo4j.server.webserver.address|g" /var/lib/neo4j/conf/neo4j-server.properties && \
     sed -i "s|#org.neo4j.server.thirdparty_jaxrs_classes=org.neo4j.examples.server.unmanaged=/examples/unmanaged|org.neo4j.server.thirdparty_jaxrs_classes=extension=/service|g" /var/lib/neo4j/conf/neo4j-server.properties
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Neo4j Community Edition 2.1.7
+# Neo4j Community Edition 2.2.0
 
-This repository contains a Docker image of the latest version (2.1.7) of the [Neo4j community server](http://www.neo4j.com/download). This Docker image of Neo4j provides instructions on how to map a Docker data volume to an already existing `data/graph.db` store file located on your host machine.
+This repository contains a Docker image of the latest version (2.2.0) of the [Neo4j community server](http://www.neo4j.com/download). This Docker image of Neo4j provides instructions on how to map a Docker data volume to an already existing `data/graph.db` store file located on your host machine.
 
 # What is Neo4j?
 
@@ -27,7 +27,7 @@ docker pull kbastani/docker-neo4j
 To run the Neo4j image inside a container after either building it or pulling it, run the following docker command.
 
 ```
-docker run -d -P -v /Users/<user>/path/to/neo4j/data:/opt/data --name graphdb kbastani/docker-neo4j
+docker run -d -p 7474:7474 -v /Users/<user>/path/to/neo4j/data:/opt/data --name graphdb kbastani/docker-neo4j
 ```
 
 Make sure to replace the `<user>` with the user directory that contains your Neo4j `graph.db` data store files.

--- a/conf/neo4j/neo4j.properties
+++ b/conf/neo4j/neo4j.properties
@@ -1,12 +1,25 @@
-# Default values for the low-level graph engine
-neostore.nodestore.db.mapped_memory=1024m
-neostore.relationshipstore.db.mapped_memory=4192M
-neostore.propertystore.db.mapped_memory=500M
-neostore.propertystore.db.strings.mapped_memory=500M
-neostore.propertystore.db.arrays.mapped_memory=500M
+################################################################
+# Neo4j
+#
+# neo4j.properties - database tuning parameters
+#
+################################################################
 
-# Enable this to be able to upgrade a store from an older version
+# Enable this to be able to upgrade a store from an older version.
 allow_store_upgrade=true
+
+# The amount of memory to use for mapping the store files, in bytes (or
+# kilobytes with the 'k' suffix, megabytes with 'm' and gigabytes with 'g').
+# If Neo4j is running on a dedicated server, then it is generally recommended
+# to leave about 2-4 gigabytes for the operating system, give the JVM enough
+# heap to hold all your transaction state and query context, and then leave the
+# rest for the page cache.
+# The default page cache memory assumes the machine is dedicated to running
+# Neo4j, and is heuristically set to 75% of RAM minus the max Java heap size.
+#dbms.pagecache.memory=10g
+
+# The type of cache to use for nodes and relationships.
+cache_type=soft
 
 # Enable this to specify a parser other than the default one.
 #cypher_parser_version=2.0
@@ -20,25 +33,10 @@ wrapper.java.maxmemory=12000
 # legacy reasons To limit space needed to store historical logs use values such
 # as: "7 days" or "100M size" instead of "true"
 keep_logical_logs=true
-cache_type=none
-
-# Autoindexing
-
-# Enable auto-indexing for nodes, default is false
-#node_auto_indexing=true
-
-# The node property keys to be auto-indexed, if enabled
-#node_keys_indexable=name,age
-
-# Enable auto-indexing for relationships, default is false
-#relationship_auto_indexing=true
-
-# The relationship property keys to be auto-indexed, if enabled
-#relationship_keys_indexable=name,age
 
 # Enable shell server so that remote clients can connect via Neo4j shell.
-#remote_shell_enabled=true
+remote_shell_enabled=true
 # The network interface IP the shell will listen on (use 0.0.0 for all interfaces)
 remote_shell_host=0.0.0.0
 # The port the shell will listen on, default is 1337
-#remote_shell_port=1337
+remote_shell_port=1337


### PR DESCRIPTION
Updated dependencies to Neo4j 2.2.0 release. 

Upgraded neo4j-graph-analytics unmanaged extension to 1.1.0 to support the Neo4j 2.2.0 kernel changes from 2.1.7.
