### PR TITLE
Version 2.2.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,16 @@ MAINTAINER K.B. Name <kb@socialmoon.com>
 
 ENV HDFS_HOST hdfs://hdfs:9000
 
+ENV NEO4j_VERSION community-2.2.3
+#ENV NEO4j_VERSION enterprise-2.2.3
+
 # Install Neo4j
-RUN wget -O - http://debian.neo4j.org/neotechnology.gpg.key | apt-key add - && \
-    echo 'deb http://debian.neo4j.org/repo stable/' > /etc/apt/sources.list.d/neo4j.list && \
-    apt-get update ; apt-get install neo4j -y
+RUN apt-get update && \
+    apt-get install -y wget
+RUN wget -q -O /tmp/neo4j-$NEO4j_VERSION-unix.tar.gz http://dist.neo4j.org/neo4j-$NEO4j_VERSION-unix.tar.gz && \
+    tar -zxf /tmp/neo4j-$NEO4j_VERSION-unix.tar.gz -C /var/lib && \
+    ln -s /var/lib/neo4j-$NEO4j_VERSION /var/lib/neo4j && \
+    wget -q -O /var/lib/neo4j/lib/gson-2.2.4.jar http://search.maven.org/remotecontent?filepath=com/google/code/gson/gson/2.2.4/gson-2.2.4.jar
 
 WORKDIR /var/lib/neo4j
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Neo4j Community Edition 2.2.1
+# Neo4j Community Edition 2.2.3
 
-This repository contains a Docker image of the latest version (2.2.1) of the [Neo4j community server](http://www.neo4j.com/download). This Docker image of Neo4j provides instructions on how to map a Docker data volume to an already existing `data/graph.db` store file located on your host machine.
+This repository contains a Docker image of the latest version (2.2.3) of the [Neo4j community server](http://www.neo4j.com/download). This Docker image of Neo4j provides instructions on how to map a Docker data volume to an already existing `data/graph.db` store file located on your host machine.
 
 # What is Neo4j?
 
@@ -77,4 +77,21 @@ The Neo4j server container is now accessible on your host machine with the follo
 
 ```
 http://graphdb:7474/browser
+```
+
+### Alternative approach for Mac OS X: Use boot2docker ip
+
+If you don't want to set up a route, you can just use the boot2docker ip to connect to the container.
+
+```bash
+boot2docker ip  # usually returns 192.168.59.103
+```
+
+The container can be reached from the host via the IP above. Try to access neo4j via your browser `http://192.168.59.103:7474` or via `curl`
+```bash
+$ curl 192.168.59.103:7474
+{
+  "management" : "http://172.17.0.16:7474/db/manage/",
+  "data" : "http://172.17.0.16:7474/db/data/"
+}%
 ```


### PR DESCRIPTION
I have updated the Dockerfile to explicitly install version 2.2.3 (community version). A `docker pull kbastani/docker-neo4j` gave me version 2.2.2, which unfortunately does have problems with volumes on Mac OS X. In version 2.2.3 those issues are resolved, as described by [@anentropic ](https://github.com/kbastani/docker-neo4j/issues/4#issuecomment-119305201) 

This PR would resolve the problems in issue #4. I am not sure if it is in your interest to lock down a specific version as I have done it. Perhaps you might want to include it in a 2.2.3-branch or something like that.

I also do have extended the readme to show a alternative way to access the container from web browsers or curl by using the boot2docker IP instead of creating routes as you have suggested it in the readme.
